### PR TITLE
Drop precompile from parts in standard-deployment.cfg

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -10,6 +10,11 @@ extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
 
+# Drop plone.recipe.precompiler in order to avoid scanning the entire
+# deployment directory when using policies / buildouts with develop = .
+parts -=
+    precompile
+
 usernamelogger_ac_cookie_name = __ac
 raven_project_dist = opengever.core
 


### PR DESCRIPTION
Drop precompile from parts in `standard-deployment.cfg` in order to avoid scanning the entire deployment directory when using policies / buildouts with `develop = .`

@deiferni @phgross 
