### PR TITLE
install haproxy supervisor integration.

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -9,6 +9,7 @@ extends =
     http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg
 
 # Drop plone.recipe.precompiler in order to avoid scanning the entire
 # deployment directory when using policies / buildouts with develop = .


### PR DESCRIPTION
Install and configure `supervisor-haproxy` by extending the `ftw-buildouts`' standard configuration in order to let haproxy know when the availability of instances changes in supervisor (start/stop/restart).

**Resources:**
- [`ftw-buildouts` readme](https://github.com/4teamwork/ftw-buildouts#haproxy-supervisor-integration)
- [`supervisor-haproxy` docu](https://pypi.python.org/pypi/supervisor-haproxy)

**Requirements:**
- haproxy ipv4 stats socket: available on `heta` and all puppet-development deployments.
- haproxy programe schema `plone0101`, as standard for puppet deployments.

If those requirements are not fulfilled, the haproxy supervisor eventlistener will not work but also not do any harm.

**Benefit:**
HaProxy will know much faster when an instance goes down or is available, leading to a faster and more stable response experience in general. Especially when doing zero-downtime deployments it will lead to less bad responses / proxy errors.

/cc @deiferni @lukasgraf @phgross @Rotonen 