### PR TITLE
Add standard buildouts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,66 @@ extends =
 **WARNING:** The sources of the `master`-branch is extended because we cannot
   use the branch variable in the `extends`. You need to write your own
   `source-master.cfg` if you need to deploy another branch.
+
+
+## [standard-dev.cfg](https://github.com/4teamwork/gever-buildouts/blob/master/standard-dev.cfg)
+
+The `standard-dev.cfg` is a standard development config to be used in
+standardized GEVER policies. It may or may not be used by more sophisticated
+policies.
+
+The goal is to make the `development.cfg` in a standard GEVER policy as short as
+possible
+
+Usage example:
+```ini
+[buildout]
+extends =
+    test-policy.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-dev.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
+
+ogds-db-name = opengeverftw
+```
+
+
+## [test-policy.cfg](https://github.com/4teamwork/gever-buildouts/blob/master/test-policy.cfg)
+
+The `test-policy.cfg` tests whether policy development works with the
+`opengever.core` version installed in production.
+The GEVER version installed in production might not be the newest, therefore the
+test buildout in the policy package should extend a KGS version.
+
+This config is usually extended in a GEVER policy in a config file with the same
+name `test-policy.cfg`:
+
+```ini
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/test-policy.cfg
+    versions.cfg
+
+package-name = opengever.ftw
+```
+
+
+## [test-core-development.cfg](https://github.com/4teamwork/gever-buildouts/blob/master/test-core-development.cfg)
+
+The `test-core-development.cfg` tests whether the lastest `opengever.core`
+development still works with a policy.
+
+The goal is to notice when a change in `opengever.core` will break our policy so
+that an upgrade will be problematic in the future.
+This allows us to fix the problems when the knowledge is fresh, so that later
+updates will be easy.
+
+
+This config is usually extended in a GEVER policy in a config file with the same
+name `test-core-development.cfg`:
+
+```ini
+[buildout]
+extends = https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/test-core-development.cfg
+package-name = opengever.ftw
+```

--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -1,0 +1,45 @@
+# Standard development config to be used in standardized policies.
+# May or may not be used by more sophisticated policies.
+
+# Usage:
+# [buildout]
+# extends =
+#     test-policy.cfg
+#     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+#     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-dev.cfg
+#
+# ogds-db-name = ???
+
+[buildout]
+extends =
+    http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
+
+instance-eggs +=
+    opengever.core
+    psycopg2
+
+zcml-additional-fragments +=
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:db="http://namespaces.zope.org/db">
+
+        <include package="z3c.saconfig" file="meta.zcml" />
+
+        <db:engine name="opengever.db"
+          url="postgresql+psycopg2:///${buildout:ogds-db-name}" pool_recycle="3600" />
+        <db:session name="opengever" engine="opengever.db" />
+    </configure>
+
+
+[instance]
+zserver-threads = 4
+user = zopemaster:admin
+zope-conf-additional +=
+    datetime-format international
+    <product-config opengever.core>
+        ogds_log_file ${buildout:directory}/var/log/ogds-update.log
+    </product-config>
+
+environment-vars +=
+    IS_DEVELOPMENT_MODE True
+    SABLON_BIN ${buildout:sablon-executable}

--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -32,7 +32,7 @@ zcml-additional-fragments +=
 
 
 [instance]
-zserver-threads = 4
+zserver-threads = 1
 user = zopemaster:admin
 zope-conf-additional +=
     datetime-format international

--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -1,15 +1,3 @@
-# Standard development config to be used in standardized policies.
-# May or may not be used by more sophisticated policies.
-
-# Usage:
-# [buildout]
-# extends =
-#     test-policy.cfg
-#     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
-#     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-dev.cfg
-#
-# ogds-db-name = ???
-
 [buildout]
 extends =
     http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg

--- a/test-core-development.cfg
+++ b/test-core-development.cfg
@@ -1,0 +1,13 @@
+# Tests whether the lastest opengever.core development still works with a policy.
+# Should be extended within the policy package.
+
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-4.3.2.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/master/sources.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg
+
+development-packages += opengever.core
+
+# package-name = opengever.fancycustomer

--- a/test-core-development.cfg
+++ b/test-core-development.cfg
@@ -8,3 +8,7 @@ extends =
 
 jenkins_python = $PYTHON27
 development-packages += opengever.core
+
+
+[test]
+eggs += ${buildout:hotfix-eggs}

--- a/test-core-development.cfg
+++ b/test-core-development.cfg
@@ -3,11 +3,13 @@
 
 [buildout]
 extends =
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-4.3.2.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/master/sources.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg
 
+jenkins_python = $PYTHON27
 development-packages += opengever.core
 
 # package-name = opengever.fancycustomer

--- a/test-core-development.cfg
+++ b/test-core-development.cfg
@@ -1,6 +1,3 @@
-# Tests whether the lastest opengever.core development still works with a policy.
-# Should be extended within the policy package.
-
 [buildout]
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
@@ -11,5 +8,3 @@ extends =
 
 jenkins_python = $PYTHON27
 development-packages += opengever.core
-
-# package-name = opengever.fancycustomer

--- a/test-policy.cfg
+++ b/test-policy.cfg
@@ -1,0 +1,11 @@
+# Tests whether policy development works with the opengever.core version installed
+# in production (may not be the newest).
+# Should be extended within the policy package.
+
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+
+
+jenkins_python = $PYTHON27

--- a/test-policy.cfg
+++ b/test-policy.cfg
@@ -4,3 +4,7 @@ extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
 
 jenkins_python = $PYTHON27
+
+
+[test]
+eggs += ${buildout:hotfix-eggs}

--- a/test-policy.cfg
+++ b/test-policy.cfg
@@ -1,11 +1,6 @@
-# Tests whether policy development works with the opengever.core version installed
-# in production (may not be the newest).
-# Should be extended within the policy package.
-
 [buildout]
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
-
 
 jenkins_python = $PYTHON27


### PR DESCRIPTION
Adds standard buildouts:
- `test-core-development.cfg`
- `test-policy.cfg`
- `standard-dev.cfg`

For the discussion and usage example please refer to https://github.com/4teamwork/opengever.ftw/pull/9.
For in-depth discussion please use the above PR.

// @deiferni @lukasgraf @Rotonen @phgross 