### PR TITLE
Development buildout updates

### DIFF
--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -1,7 +1,4 @@
 [buildout]
-extends =
-    http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
-
 instance-eggs +=
     opengever.core
     psycopg2
@@ -30,4 +27,3 @@ zope-conf-additional +=
 
 environment-vars +=
     IS_DEVELOPMENT_MODE True
-    SABLON_BIN ${buildout:sablon-executable}

--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -1,4 +1,7 @@
 [buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+
 instance-eggs +=
     opengever.core
     psycopg2


### PR DESCRIPTION
Followup to #4:

I have realized that ruby-gems / sablon [is an optional feature](https://github.com/4teamwork/opengever.core/blob/252b04dfcf9e5c64d64bdc8f0cc928e19b9062f4/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob#L5-L7) and should not be included in `standard-dev.cfg`.

I have therefore stopped `standard-dev.cfg` from extending and configuring `ruby-gems.cfg`; this should no be done in the policy package's `development.cfg`.

This allowed me to add the extends to `plone-development.cfg` which I couldn't add before because of buildouts multi-level-extends-bugs. The extends should be removed from the policy package's `development.cfg`.

/cc @phgross @Rotonen 