### PR TITLE
load opengever.maintenance in development too.

### DIFF
--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -4,6 +4,7 @@ extends =
 
 instance-eggs +=
     opengever.core
+    opengever.maintenance
     psycopg2
 
 zcml-additional-fragments +=


### PR DESCRIPTION
opengever.maintenance (ZCML) is loaded in production, therefore it should be loaded in policy development, too.