### PR TITLE
install bin/slacker by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ such as:
 - warmup: automatically warmup instances after start
 - `standard-sources.cfg` (see below)
 - standard eggs such as `opengever.maintenance` and `ftw.zopemaster`
+- sets up a [`bin/slacker`](https://github.com/4teamwork/ftw-buildouts#slack),
+  which requires a server-wide environment variable `$STANDARD_SLACK_WEBHOOK`
+  containing the slack hook url.
 
 **Variables:**
 - `buildout:deployment-number`: deployment number, prefixing all ports

--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -10,6 +10,7 @@ extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/slacker.cfg
 
 # Drop plone.recipe.precompiler in order to avoid scanning the entire
 # deployment directory when using policies / buildouts with develop = .
@@ -18,6 +19,7 @@ parts -=
 
 usernamelogger_ac_cookie_name = __ac
 raven_project_dist = opengever.core
+slack-webhook = $STANDARD_SLACK_WEBHOOK
 
 instance-eggs +=
     opengever.core


### PR DESCRIPTION
Set up a `bin/slacker` script.
The slacker hook url is set to the enviroment variable
`$STANDARD_SLACK_WEBHOOK` so that it can be configured per server.

Alternatively it can be override per-deployment, see the ftw-buildouts
readme for more details about a standard configuration.

https://github.com/4teamwork/ftw-buildouts#slack

/cc @Rotonen 