### PR TITLE
configure maintenance page for all deployments.

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -11,6 +11,7 @@ extends =
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/slacker.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/maintenance-server.cfg
 
 # Drop plone.recipe.precompiler in order to avoid scanning the entire
 # deployment directory when using policies / buildouts with develop = .
@@ -20,6 +21,7 @@ parts -=
 usernamelogger_ac_cookie_name = __ac
 raven_project_dist = opengever.core
 slack-webhook = $STANDARD_SLACK_WEBHOOK
+maintenance-directory = ${buildout:directory}/src/opengever.maintenance/maintenance-page
 
 instance-eggs +=
     opengever.core


### PR DESCRIPTION
opengever.maintenance must be checked out and contains a `maintenance-page/index.html`.

Requires HaProxy change https://git.4teamwork.ch/misc/puppet/merge_requests/54