### PR TITLE
Use ftw.upgrade colors extra for source deployments.

### DIFF
--- a/source-master.cfg
+++ b/source-master.cfg
@@ -18,3 +18,6 @@ auto-checkout =
 # otherwise you want to make your own copy of this file!
 # Be sure to change the branch-name then in the extends at line 2.
 opengever.core = master
+
+[upgrade]
+eggs += ftw.upgrade[colors]


### PR DESCRIPTION
We should use colors to visually distinguish orphaned upgrade steps. Having an orphaned upgrade step on a deployment will require action, i.e. touching the upgrade to avoid re-installing an already installed upgrade. This PR includes the  `colors` extra from `ftw.upgrade` for source deployments.

**no colors:**

![screen shot 2017-02-07 at 13 24 53](https://cloud.githubusercontent.com/assets/736583/22691379/8248ee22-ed3a-11e6-86fd-3ac9cf95d981.png)

**vs. colors:**

![screen shot 2017-02-07 at 13 24 45](https://cloud.githubusercontent.com/assets/736583/22691378/821743e0-ed3a-11e6-99ef-226f93091b4d.png)
