### PR TITLE
Remove *.cfg based dependency to chameleon.

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -30,6 +30,12 @@ instance-eggs +=
     ftw.zopemaster
     ftw.raven
 
+# We want to enable chameleon based on a setup.py dependency in opengever.core
+# not on a per-buildout base, so we remove ftw.chameleon from the instance-eggs. It is
+# added by chameleon.cfg in fhe first place, wich we'd like to reuse.
+instance-eggs -=
+    ftw.chameleon
+
 zcml-additional-fragments +=
     <include package="${buildout:client-policy}" />
 


### PR DESCRIPTION
We want to enable chameleon based on a setup.py dependency in opengever.core
not on a per-buildout base, so we remove ftw.chameleon from the instance-eggs.
It is added by chameleon.cfg in fhe first place, wich we'd like to reuse.