### PR TITLE
Move ruby-gems.cfg from other repo

### DIFF
--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -17,6 +17,7 @@ cmds=
     printf "source 'https://rubygems.org'\n" > Gemfile
     printf "ruby '${ruby-versions:ruby}'\n" >> Gemfile
     printf "gem 'sablon', '${ruby-versions:sablon}'" >> Gemfile
+    printf "gem 'nokogiri', '${ruby-versions:nokogiri}'" >> Gemfile
     printf "${ruby-versions:ruby}" > .ruby-version
     bundle install --binstubs --path ${buildout:ruby-gem-directory}
 

--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -1,0 +1,32 @@
+# this file is intended for opengever development.cfg
+[buildout]
+parts += gems
+
+ruby-gem-directory = ${buildout:parts-directory}/gems
+sablon-executable = ${buildout:ruby-gem-directory}/bin/sablon
+
+[gems]
+recipe = collective.recipe.cmd
+on_install=true
+on_update=true
+cmds=
+    set -euo pipefail
+    mkdir -p ${buildout:ruby-gem-directory}
+    cd ${buildout:ruby-gem-directory}
+    printf "source 'https://rubygems.org'\n" > Gemfile
+    printf "ruby '${ruby-versions:ruby}'\n" >> Gemfile
+    printf "gem 'sablon', '${ruby-versions:sablon}'" >> Gemfile
+    printf "${ruby-versions:ruby}" > .ruby-version
+    bundle install --binstubs --path ${buildout:ruby-gem-directory}
+
+uninstall_cmds=
+    set -euo pipefail
+    rm -r ${buildout:ruby-gem-directory}/bin
+    rm -r ${buildout:ruby-gem-directory}/ruby
+    rm -r ${buildout:ruby-gem-directory}/.bundle
+    rm ${buildout:ruby-gem-directory}/.ruby-version
+    rm ${buildout:ruby-gem-directory}/Gemfile
+    rmdir ${buildout:ruby-gem-directory}
+
+[ruby-versions]
+# ruby-versions are defined in our KGS starting at opengever relase 3.2

--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -9,6 +9,7 @@ sablon-executable = ${buildout:ruby-gem-directory}/bin/sablon
 recipe = collective.recipe.cmd
 on_install=true
 on_update=true
+shell=/bin/bash
 cmds=
     set -euo pipefail
     mkdir -p ${buildout:ruby-gem-directory}

--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -15,6 +15,8 @@ cmds=
     mkdir -p ${buildout:ruby-gem-directory}
     cd ${buildout:ruby-gem-directory}
     touch .matrixignore
+    # Make sure we have a bundler
+    if [[ ! $(gem list | grep -c bundler) -eq 1 ]]; then gem install bundler; fi
     printf "source 'https://rubygems.org'\n" > Gemfile
     printf "ruby '${ruby-versions:ruby}'\n" >> Gemfile
     printf "gem 'sablon', '${ruby-versions:sablon}'\n" >> Gemfile

--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -16,7 +16,7 @@ cmds=
     touch .matrixignore
     printf "source 'https://rubygems.org'\n" > Gemfile
     printf "ruby '${ruby-versions:ruby}'\n" >> Gemfile
-    printf "gem 'sablon', '${ruby-versions:sablon}'" >> Gemfile
+    printf "gem 'sablon', '${ruby-versions:sablon}'\n" >> Gemfile
     printf "gem 'nokogiri', '${ruby-versions:nokogiri}'" >> Gemfile
     printf "${ruby-versions:ruby}" > .ruby-version
     bundle install --binstubs --path ${buildout:ruby-gem-directory}

--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -13,6 +13,7 @@ cmds=
     set -euo pipefail
     mkdir -p ${buildout:ruby-gem-directory}
     cd ${buildout:ruby-gem-directory}
+    touch .matrixignore
     printf "source 'https://rubygems.org'\n" > Gemfile
     printf "ruby '${ruby-versions:ruby}'\n" >> Gemfile
     printf "gem 'sablon', '${ruby-versions:sablon}'" >> Gemfile
@@ -24,6 +25,7 @@ uninstall_cmds=
     rm -r ${buildout:ruby-gem-directory}/bin
     rm -r ${buildout:ruby-gem-directory}/ruby
     rm -r ${buildout:ruby-gem-directory}/.bundle
+    rm ${buildout:ruby-gem-directory}/.matrixignore
     rm ${buildout:ruby-gem-directory}/.ruby-version
     rm ${buildout:ruby-gem-directory}/Gemfile
     rm ${buildout:ruby-gem-directory}/Gemfile.lock

--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -26,6 +26,7 @@ uninstall_cmds=
     rm -r ${buildout:ruby-gem-directory}/.bundle
     rm ${buildout:ruby-gem-directory}/.ruby-version
     rm ${buildout:ruby-gem-directory}/Gemfile
+    rm ${buildout:ruby-gem-directory}/Gemfile.lock
     rmdir ${buildout:ruby-gem-directory}
 
 [ruby-versions]

--- a/ruby-gems.cfg
+++ b/ruby-gems.cfg
@@ -15,8 +15,6 @@ cmds=
     mkdir -p ${buildout:ruby-gem-directory}
     cd ${buildout:ruby-gem-directory}
     touch .matrixignore
-    # Make sure we have a bundler
-    if [[ ! $(gem list | grep -c bundler) -eq 1 ]]; then gem install bundler; fi
     printf "source 'https://rubygems.org'\n" > Gemfile
     printf "ruby '${ruby-versions:ruby}'\n" >> Gemfile
     printf "gem 'sablon', '${ruby-versions:sablon}'\n" >> Gemfile


### PR DESCRIPTION
Move the `ruby-gems.cfg` from `opengever-buildouts` to this repository. Also include its history.