### PR TITLE
Update ruby-gems location and always include it for dev

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -7,7 +7,7 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/chameleon.cfg
-    http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg

--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -2,6 +2,7 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/chameleon.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
 
 instance-eggs +=
     opengever.core


### PR DESCRIPTION
Always include `ruby-gems` for development and update its location to download from this repo.