### PR TITLE
Also include SABLON_BIN environment variable for dev.

### DIFF
--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -38,3 +38,4 @@ zope-conf-additional +=
 
 environment-vars +=
     IS_DEVELOPMENT_MODE True
+    SABLON_BIN ${buildout:sablon-executable}


### PR DESCRIPTION
The buildout-variable is defined by `ruby-gems.cfg` already, so we should include it in the dev buildout here, too.