### PR TITLE
No longer provide default db name.

### DIFF
--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -1,10 +1,12 @@
 [buildout]
+# Variables:
+# ogds-db-name = gever-X
+
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/chameleon.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
 
-ogds-db-name = opengever
 ogds-dsn-postgres = postgresql+psycopg2:///${buildout:ogds-db-name}
 ogds-dsn = ${buildout:ogds-dsn-postgres}
 ogds-db-driver = psycopg2


### PR DESCRIPTION
Always force the extender to define its own database name. Helps
to avoid accidentilly overwrites while developing.