### PR TITLE
Remove the faulty and partly unnecessary HAProxy supervisord plugin

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -10,7 +10,6 @@ extends =
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/slacker.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/maintenance-server.cfg
 


### PR DESCRIPTION
This plugin has a tendency of bringing both itself and the supervisord into non-waiting loops. Also in the way we do our deployments there is no actual need to handle this properly.