### PR TITLE
Revert "Remove the faulty and partly unnecessary HAProxy supervisord plugin

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -10,6 +10,7 @@ extends =
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/slacker.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/maintenance-server.cfg
 


### PR DESCRIPTION
This is again in a deployable condition per https://github.com/4teamwork/supervisor-haproxy/pull/5.

This reverts commit 0aa95a16452a48e1c99ddba1b2100d180e572ab2.