### PR TITLE
Include ftw.contentstats in standard GEVER deployments

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -28,6 +28,7 @@ instance-eggs +=
     opengever.maintenance
     ftw.zopemaster
     ftw.raven
+    ftw.contentstats
 
 # We want to enable chameleon based on a setup.py dependency in opengever.core
 # not on a per-buildout base, so we remove ftw.chameleon from the instance-eggs. It is


### PR DESCRIPTION
`ftw.contentstats` needs to be added to the instance eggs directly (as opposed to just include it in og.core's setup.py) in order for the `bin/dump-content-stats` console_script to be built.

⚠️  **Note**: This will mean that existing buildouts with an older version of `opengever.core` will first fail (because of a picked version) until an `ftw.contentstats` version is pinned for that buildout.