### PR TITLE
Add configurable zope manager group.

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -30,6 +30,8 @@ instance-eggs +=
     ftw.raven
     ftw.contentstats
 
+zope-manager-group = cn=gever-zope-managers,ou=groups,dc=4teamwork,dc=ch
+
 # We want to enable chameleon based on a setup.py dependency in opengever.core
 # not on a per-buildout base, so we remove ftw.chameleon from the instance-eggs. It is
 # added by chameleon.cfg in fhe first place, wich we'd like to reuse.
@@ -39,9 +41,17 @@ instance-eggs -=
 zcml-additional-fragments +=
     <include package="${buildout:client-policy}" />
 
+zope-manager-configuration =
+    <product-config ftw.zopemaster>
+        manager_group ${zope-manager-group}
+    </product-config>
+
 [instance0]
 environment-vars +=
     SABLON_BIN ${buildout:sablon-executable}
     USERNAMELOGGER_AC_COOKIE_NAME ${buildout:usernamelogger_ac_cookie_name}
     RAVEN_PROJECT_DIST ${buildout:raven_project_dist}
     RAVEN_TAGS ${buildout:raven_tags}
+
+zope-conf-additional +=
+    ${buildout:zope-manager-configuration}


### PR DESCRIPTION
This overrides the ftw.zopemaster group, which provides a generic value.

It defaults to a gever specific zope manager group which limits access.