### PR TITLE
Fix variable substitution in zope manager configuration.

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -43,7 +43,7 @@ zcml-additional-fragments +=
 
 zope-manager-configuration =
     <product-config ftw.zopemaster>
-        manager_group ${zope-manager-group}
+        manager_group ${buildout:zope-manager-group}
     </product-config>
 
 [instance0]


### PR DESCRIPTION
Should be `${buildout:zope-manager-group}` instead of just `${zope-manager-group}`.