### PR TITLE
Load opengever.core's zcml before plone,

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -46,6 +46,9 @@ zope-manager-configuration =
         manager_group ${buildout:zope-manager-group}
     </product-config>
 
+instance-zcml +=
+    opengever.core
+
 [instance0]
 environment-vars +=
     SABLON_BIN ${buildout:sablon-executable}


### PR DESCRIPTION
to make sure that the plone translations customizations in opengever.core are loaded correctly. 

Policy packages with their own translation overwrite can now uses the new `early-zcml` slug from ftw-buildouts (see https://github.com/4teamwork/ftw-buildouts/pull/135)