### PR TITLE
Add a common base config for saas deployments

### DIFF
--- a/saas-deployment.cfg
+++ b/saas-deployment.cfg
@@ -1,0 +1,14 @@
+[buildout]
+# This is intended to be used as the base to extend from for SaaS deployments
+#
+# Common features:
+# * OGDS in PostgreSQL
+# * Solr enabled
+# * Bumblebee enabled
+
+extends =
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-deployment-v2.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ogds-postgres.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production-v2.cfg


### PR DESCRIPTION
_Harvest: `OneGov GEVER` - `Softwarepflege (Refactoring/Bug)`_

* Added a new common buildout for our SaaS deployments
  * OGDS is always in PostgreSQL for SaaS deployments
  * Solr is always enabled for SaaS deployments
  * Bumblebee is always enabled for SaaS deployments
  * All SaaS deployments are production-v2 buildouts
* The number of ZEO clients is configured per policy

This is for https://github.com/4teamwork/opengever.core/issues/5409