### PR TITLE
Pin ftw.monitor to 1.0.0

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -58,3 +58,6 @@ environment-vars +=
 
 zope-conf-additional +=
     ${buildout:zope-manager-configuration}
+
+[versions]
+ftw.monitor = 1.0.0


### PR DESCRIPTION
We provide a version pin here (for now) in order to not be tied to a particular released version of GEVER when rolling out `ftw.monitor`.