### PR TITLE
Solr dataimport instance

### DIFF
--- a/solr.cfg
+++ b/solr.cfg
@@ -4,9 +4,6 @@
 
 extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/solr-v2.cfg
 
-parts +=
-    solr-di
-
 [solr]
 conf-egg = opengever.core
 conf = /solr-conf

--- a/solr.cfg
+++ b/solr.cfg
@@ -4,6 +4,13 @@
 
 extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/solr-v2.cfg
 
+parts +=
+    solr-di
+
 [solr]
 conf-egg = opengever.core
 conf = /solr-conf
+
+[solr-di]
+<= solr
+port = 1${buildout:deployment-number}31

--- a/source-master.cfg
+++ b/source-master.cfg
@@ -4,7 +4,7 @@
 
 [buildout]
 extends =
-    https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/solr-update-840/versions.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/master/sources.cfg
 
 auto-checkout += opengever.core

--- a/source-master.cfg
+++ b/source-master.cfg
@@ -4,7 +4,7 @@
 
 [buildout]
 extends =
-    https://raw.githubusercontent.com/4teamwork/opengever.core/solr-update-840/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/master/sources.cfg
 
 auto-checkout += opengever.core


### PR DESCRIPTION
Adds an additional Solr instance for reindexing Solr.
See also https://github.com/4teamwork/opengever-deployments/pull/33

`solr-di` is currently not added to `parts` as this results in a buildout bug.
Reindexing works without having it in `parts` as it installs the `solr-di` part explicitly.

https://github.com/4teamwork/opengever.core/pull/6180 should me merged first and modifications to `source-master.cfg` should be discarded.