### PR TITLE
Keep log files for 1 year

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -59,5 +59,14 @@ environment-vars +=
 zope-conf-additional +=
     ${buildout:zope-manager-configuration}
 
+[deployment]
+# Retain logfiles for 1 year
+logrotate-options =
+    rotate 52
+    weekly
+    missingok
+    notifempty
+    nomail
+
 [versions]
 ftw.monitor = 1.0.0


### PR DESCRIPTION
The default of 4 weeks is not enough for access logs.