### PR TITLE
Don't extend from ruby-gems.cfg for Sablon anymore

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -7,7 +7,6 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/chameleon.cfg
-    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/slacker.cfg

--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -50,7 +50,7 @@ instance-zcml +=
 
 [instance0]
 environment-vars +=
-    SABLON_BIN ${buildout:sablon-executable}
+    SABLON_BIN /opt/sablon/bin/sablon
     USERNAMELOGGER_AC_COOKIE_NAME ${buildout:usernamelogger_ac_cookie_name}
     RAVEN_PROJECT_DIST ${buildout:raven_project_dist}
     RAVEN_TAGS ${buildout:raven_tags}

--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -5,7 +5,6 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/chameleon.cfg
-    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
 
 development-parts +=
     test-inbound-mail

--- a/standard-dev.cfg
+++ b/standard-dev.cfg
@@ -47,7 +47,6 @@ zope-conf-additional +=
 
 environment-vars +=
     IS_DEVELOPMENT_MODE True
-    SABLON_BIN ${buildout:sablon-executable}
 
 [test-inbound-mail]
 # Usage: cat testmail.eml | bin/test-inbound-mail


### PR DESCRIPTION
Don't extend from `ruby-gems.cfg` for Sablon anymore:
Sablon is deployed on all servers either as a service (may be used by setting `SABLON_URL`) or as an RPM in `/opt/sablon/bin/sablon`.

The only exceptions to this are very old servers, which won't get a release update before they're updated.

Also statically set `SABLON_BIN` to `/opt/sablon/bin/sablon`:

Since we don't build Sablon via buildout any more, the only appropriate path is the one where Sablon might be installed via RPM on the server.

In situations where this isn't the case, because Sablon is installed as a Docker service instead, `SABLON_URL` must be configured and then takes precedence over `SABLON_BIN`.

For [CA-485](https://4teamwork.atlassian.net/browse/CA-485)