### PR TITLE
Set TUS tempfile directory

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -54,6 +54,7 @@ environment-vars +=
     USERNAMELOGGER_AC_COOKIE_NAME ${buildout:usernamelogger_ac_cookie_name}
     RAVEN_PROJECT_DIST ${buildout:raven_project_dist}
     RAVEN_TAGS ${buildout:raven_tags}
+    TUS_TMP_FILE_DIR ${buildout:directory}/var/tus-uploads
 
 zope-conf-additional +=
     ${buildout:zope-manager-configuration}


### PR DESCRIPTION
Configure a temp directory for TUS uploads shared by all instances.
This allows us to drop session stickiness for TUS uploads.

JIRA: https://4teamwork.atlassian.net/browse/CA-2227