### PR TITLE
Pin stdlib-list to last python 2 compatible version.

### DIFF
--- a/test-policy.cfg
+++ b/test-policy.cfg
@@ -8,3 +8,7 @@ jenkins_python = $PYTHON27
 
 [test]
 eggs += ${buildout:hotfix-eggs}
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9


### PR DESCRIPTION
Should fix failing policy tests.
It seems that our policy tests only use https://github.com/4teamwork/ftw-buildouts/blob/master/test-base.cfg, and not any of the plone version specific files where we pinned `stdlib-list`. As we do not want to pin `stdlib-list` in `test-base.cfg`, we instead pin it here