### PR TITLE
Pin stdlib-list to last python 2 compatible version for core development tests.

### DIFF
--- a/test-core-development.cfg
+++ b/test-core-development.cfg
@@ -12,3 +12,7 @@ development-packages += opengever.core
 
 [test]
 eggs += ${buildout:hotfix-eggs}
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9


### PR DESCRIPTION
One more... In https://github.com/4teamwork/gever-buildouts/pull/36 I fixed for the `test-policy.cfg` but not for `test-core-development.cfg` see for example https://ci.4teamwork.ch/builds/565203/tasks/1127412