### PR TITLE
Fix find-links for Gitlab packages

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -12,6 +12,16 @@ extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/slacker.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/maintenance-server.cfg
 
+find-links +=
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/docxcompose
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-bumblebee
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-flamegraph
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-zopemaster
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/opengever-core
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapmultiplugins
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapuserfolder
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/relstorage
+
 # Drop plone.recipe.precompiler in order to avoid scanning the entire
 # deployment directory when using policies / buildouts with develop = .
 parts -=

--- a/standard-sources.cfg
+++ b/standard-sources.cfg
@@ -1,11 +1,6 @@
 [buildout]
 extends =
     http://kgs.4teamwork.ch/sources.cfg
-# It is important that 4teamwork-psc.cfg is included here AND the
-# mr.developer extension is defined below.
-# When moving 4teamwork-psc to another place, the extensions might
-# be overwritten.
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
 
 extensions += mr.developer
 


### PR DESCRIPTION
- No longer extend from `4teamwork-psc.cfg`. Also removes `isotoma.buildout.basicauth` extension which is no longer needed.

- Add `find-links` for each package as Gitlab's simple index consists of subpages that aren't processed by setuptools.