### PR TITLE
Extend from 4teamwork-psc.cfg again:

### DIFF
--- a/standard-deployment.cfg
+++ b/standard-deployment.cfg
@@ -12,16 +12,6 @@ extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/slacker.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/maintenance-server.cfg
 
-find-links +=
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/docxcompose
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-bumblebee
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-flamegraph
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-zopemaster
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/opengever-core
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapmultiplugins
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapuserfolder
-    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/relstorage
-
 # Drop plone.recipe.precompiler in order to avoid scanning the entire
 # deployment directory when using policies / buildouts with develop = .
 parts -=

--- a/standard-sources.cfg
+++ b/standard-sources.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends =
     http://kgs.4teamwork.ch/sources.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/lg/list-gitlab-packages/4teamwork-psc.cfg
 
 extensions += mr.developer
 


### PR DESCRIPTION
Extend from `4teamwork-psc.cfg` again: Links to private Python packages are now defined in [`4teamwork-psc.cfg`](https://github.com/4teamwork/ftw-buildouts/blob/master/4teamwork-psc.cfg), we therefore extend from it again here and remove the redundant entries to find-links.