### PR TITLE
Remove no longer available kgs and plone sources

### DIFF
--- a/standard-sources.cfg
+++ b/standard-sources.cfg
@@ -1,6 +1,5 @@
 [buildout]
 extends =
-    http://kgs.4teamwork.ch/sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
 
 extensions += mr.developer
@@ -11,3 +10,8 @@ deployment-checkouts +=
     collective.js.timeago
 
 auto-checkout += ${buildout:deployment-checkouts}
+
+[sources]
+opengever.core = git git@github.com:4teamwork/opengever.core.git
+opengever.maintenance = git git@github.com:4teamwork/opengever.maintenance.git
+collective.js.timeago = git git@github.com:collective/collective.js.timeago.git


### PR DESCRIPTION
kgs is no longer available.

See https://github.com/4teamwork/opengever.core/pull/8242/ for details.

This fix is required to fix e2e tests in gever: https://github.com/4teamwork/gever-ui/pull/2925